### PR TITLE
Add optional OrbitFabric contract adapter for host sim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,29 @@ option(OBSW_BUILD_TESTS  "Build unit tests"        ON)
 option(OBSW_BUILD_SIM    "Build host simulation"   ON)
 option(OBSW_ENABLE_ASAN  "Enable AddressSanitizer" OFF)
 
+option(
+    OBSW_ENABLE_ORBITFABRIC_CONTRACT
+    "Enable optional OrbitFabric flight contract adapter"
+    OFF
+)
+
+set(
+    ORBITFABRIC_CONTRACT_DIR
+    "${PROJECT_SOURCE_DIR}/../orbitfabric-openobsw-poc/generated_artifacts/flight_software"
+    CACHE PATH
+    "Directory containing generated OrbitFabric flight contract headers"
+)
+
+if(OBSW_ENABLE_ORBITFABRIC_CONTRACT)
+    if(NOT EXISTS "${ORBITFABRIC_CONTRACT_DIR}/mission_contract.h")
+        message(
+            FATAL_ERROR
+            "mission_contract.h not found in ORBITFABRIC_CONTRACT_DIR: "
+            "${ORBITFABRIC_CONTRACT_DIR}"
+        )
+    endif()
+endif()
+
 # Strict warnings
 add_compile_options(
     -Wall -Wextra -Wpedantic

--- a/sim/CMakeLists.txt
+++ b/sim/CMakeLists.txt
@@ -1,3 +1,24 @@
-add_executable(obsw_sim main.c sensor_inject.c)
+set(OBSW_SIM_SOURCES
+    main.c
+    sensor_inject.c
+)
+
+if(OBSW_ENABLE_ORBITFABRIC_CONTRACT)
+    list(APPEND OBSW_SIM_SOURCES orbitfabric_contract_adapter.c)
+endif()
+
+add_executable(obsw_sim ${OBSW_SIM_SOURCES})
 target_link_libraries(obsw_sim PRIVATE obsw obsw_srdb_generated m)
-target_include_directories(obsw_sim PRIVATE ${PROJECT_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
+target_include_directories(obsw_sim PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/include
+)
+
+if(OBSW_ENABLE_ORBITFABRIC_CONTRACT)
+    target_compile_definitions(obsw_sim PRIVATE
+        OBSW_ENABLE_ORBITFABRIC_CONTRACT=1
+    )
+    target_include_directories(obsw_sim PRIVATE
+        ${ORBITFABRIC_CONTRACT_DIR}
+    )
+endif()

--- a/sim/main.c
+++ b/sim/main.c
@@ -13,6 +13,10 @@
 #include "sensor_inject.h"
 #include "obsw/pus/s20.h"
 
+#ifdef OBSW_ENABLE_ORBITFABRIC_CONTRACT
+#include "orbitfabric_contract_adapter.h"
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -168,6 +172,8 @@ static const obsw_fsm_tc_entry_t safe_whitelist[] = {
     {SRDB_TC_S8_PERFORM_FUNCTION_SVC, SRDB_TC_S8_PERFORM_FUNCTION_SUBSVC},
 };
 
+#define ROUTE_INDEX_S17_PING 0U
+
 static obsw_tc_route_t routes[] = {
     {.apid = 0xFFFF, .service = 17, .subservice = 1,
      .handler = obsw_s17_ping, .ctx = &s17_ctx},
@@ -182,6 +188,32 @@ static obsw_tc_route_t routes[] = {
     {.apid = 0xFFFF, .service = 20, .subservice = 3,
      .handler = obsw_s20_get, .ctx = &s20_ctx},
 };
+
+#ifdef OBSW_ENABLE_ORBITFABRIC_CONTRACT
+static void configure_orbitfabric_contract_routes(void)
+{
+    obsw_of_tc_route_t route = {0};
+
+    if (obsw_of_tc_route_for_command(OF_CMD_PING, &route) != 0) {
+        fprintf(stderr,
+                "[OBSW] OrbitFabric contract adapter: OF_CMD_PING not mapped\n");
+        return;
+    }
+
+    routes[ROUTE_INDEX_S17_PING].apid = route.apid;
+    routes[ROUTE_INDEX_S17_PING].service = route.service;
+    routes[ROUTE_INDEX_S17_PING].subservice = route.subservice;
+
+    fprintf(stderr,
+            "[OBSW] OrbitFabric contract adapter: OF_CMD_PING -> TC(%u,%u)\n",
+            (unsigned)route.service,
+            (unsigned)route.subservice);
+}
+#else
+static void configure_orbitfabric_contract_routes(void)
+{
+}
+#endif
 
 
 /* ------------------------------------------------------------------ */
@@ -242,6 +274,8 @@ int main(void)
 obsw_wd_init(&wd_ctx, 30, on_watchdog_expiry, &s5_ctx);
 
     /* Dispatcher */
+    configure_orbitfabric_contract_routes();
+
     obsw_tc_dispatcher_t dispatcher;
     obsw_tc_dispatcher_init(&dispatcher,
                             routes, sizeof(routes) / sizeof(routes[0]),

--- a/sim/orbitfabric_contract_adapter.c
+++ b/sim/orbitfabric_contract_adapter.c
@@ -1,0 +1,22 @@
+#include "orbitfabric_contract_adapter.h"
+
+#include <stddef.h>
+
+int obsw_of_tc_route_for_command(of_cmd_id_t command_id,
+                                 obsw_of_tc_route_t *route)
+{
+    if (route == NULL) {
+        return -1;
+    }
+
+    switch (command_id) {
+    case OF_CMD_PING:
+        route->apid = 0xFFFFU;
+        route->service = 17U;
+        route->subservice = 1U;
+        return 0;
+
+    default:
+        return -1;
+    }
+}

--- a/sim/orbitfabric_contract_adapter.h
+++ b/sim/orbitfabric_contract_adapter.h
@@ -1,0 +1,25 @@
+#ifndef OBSW_SIM_ORBITFABRIC_CONTRACT_ADAPTER_H
+#define OBSW_SIM_ORBITFABRIC_CONTRACT_ADAPTER_H
+
+#include "mission_contract.h"
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    uint16_t apid;
+    uint8_t service;
+    uint8_t subservice;
+} obsw_of_tc_route_t;
+
+int obsw_of_tc_route_for_command(of_cmd_id_t command_id,
+                                 obsw_of_tc_route_t *route);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OBSW_SIM_ORBITFABRIC_CONTRACT_ADAPTER_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,3 +103,18 @@ add_executable(test_s20 unit/test_s20.c)
 target_link_libraries(test_s20 PRIVATE obsw unity)
 target_compile_options(test_s20 PRIVATE ${TEST_SUPPRESS})
 add_test(NAME s20 COMMAND test_s20)
+
+if(OBSW_ENABLE_ORBITFABRIC_CONTRACT)
+    add_executable(test_orbitfabric_contract_adapter
+        unit/test_orbitfabric_contract_adapter.c
+        ../sim/orbitfabric_contract_adapter.c
+    )
+    target_link_libraries(test_orbitfabric_contract_adapter PRIVATE unity)
+    target_include_directories(test_orbitfabric_contract_adapter PRIVATE
+        ${PROJECT_SOURCE_DIR}/sim
+        ${ORBITFABRIC_CONTRACT_DIR}
+    )
+    target_compile_options(test_orbitfabric_contract_adapter PRIVATE ${TEST_SUPPRESS})
+    add_test(NAME orbitfabric_contract_adapter
+             COMMAND test_orbitfabric_contract_adapter)
+endif()

--- a/test/unit/test_orbitfabric_contract_adapter.c
+++ b/test/unit/test_orbitfabric_contract_adapter.c
@@ -1,0 +1,43 @@
+#include "unity.h"
+
+#include "orbitfabric_contract_adapter.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_of_cmd_ping_maps_to_tc_17_1(void)
+{
+    obsw_of_tc_route_t route = {0};
+
+    TEST_ASSERT_EQUAL_INT(0, obsw_of_tc_route_for_command(OF_CMD_PING, &route));
+    TEST_ASSERT_EQUAL_UINT16(0xFFFFU, route.apid);
+    TEST_ASSERT_EQUAL_UINT8(17U, route.service);
+    TEST_ASSERT_EQUAL_UINT8(1U, route.subservice);
+}
+
+void test_invalid_command_returns_error(void)
+{
+    obsw_of_tc_route_t route = {0};
+
+    TEST_ASSERT_NOT_EQUAL(0,
+                          obsw_of_tc_route_for_command(OF_CMD_INVALID, &route));
+}
+
+void test_null_route_returns_error(void)
+{
+    TEST_ASSERT_NOT_EQUAL(0, obsw_of_tc_route_for_command(OF_CMD_PING, NULL));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_of_cmd_ping_maps_to_tc_17_1);
+    RUN_TEST(test_invalid_command_returns_error);
+    RUN_TEST(test_null_route_returns_error);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Adds a minimal optional OrbitFabric flight contract adapter for the OpenOBSW host simulator.

This is the first OpenOBSW-side consumption point for the generated OrbitFabric `mission_contract.h` artifact.

The adapter maps:

```text
OF_CMD_PING -> TC(17,1)
```

and wires that mapping into the host simulator route table only when explicitly enabled through CMake.

## Changes

- add `sim/orbitfabric_contract_adapter.h`
- add `sim/orbitfabric_contract_adapter.c`
- add optional CMake flag:

```text
OBSW_ENABLE_ORBITFABRIC_CONTRACT
```

- add configurable generated contract include directory:

```text
ORBITFABRIC_CONTRACT_DIR
```

- wire the host simulator S17 ping route through the adapter when enabled
- add a unit test for the OrbitFabric contract adapter

## Design notes

The adapter is intentionally host-sim scoped and disabled by default.

OpenOBSW standalone behavior remains unchanged.

This PR does not replace or modify the native OpenOBSW SRDB. It does not modify `srdb/data`, `srdb_generated.h`, OpenSVF, OrbitFabric Core, XTCE generation, YAMCS runtime integration, Renode, hardware targets, or CI.

This keeps the boundary explicit:

```text
OrbitFabric generated flight contract
-> optional OpenOBSW host-sim adapter
-> existing OpenOBSW PUS service route
```

## Validation

Validated locally with the Python venv using Pydantic v2.

Default OpenOBSW build, OrbitFabric adapter disabled:

```bash
rm -rf build_stage4_default

cmake -S . -B build_stage4_default \
  -DCMAKE_BUILD_TYPE=Debug \
  -DOBSW_BUILD_TESTS=ON \
  -DOBSW_BUILD_SIM=ON \
  -DPython3_EXECUTABLE="$PWD/.venv/bin/python" \
  -G Ninja

cmake --build build_stage4_default
ctest --test-dir build_stage4_default --output-on-failure
```

Result:

```text
18/18 tests passed
```

OrbitFabric-enabled build:

```bash
rm -rf build_stage4_orbitfabric

cmake -S . -B build_stage4_orbitfabric \
  -DCMAKE_BUILD_TYPE=Debug \
  -DOBSW_BUILD_TESTS=ON \
  -DOBSW_BUILD_SIM=ON \
  -DOBSW_ENABLE_ORBITFABRIC_CONTRACT=ON \
  -DORBITFABRIC_CONTRACT_DIR="$PWD/../orbitfabric-openobsw-poc/generated_artifacts/flight_software" \
  -DPython3_EXECUTABLE="$PWD/.venv/bin/python" \
  -G Ninja

cmake --build build_stage4_orbitfabric
ctest --test-dir build_stage4_orbitfabric --output-on-failure
```

Result:

```text
19/19 tests passed
```

## Non-goals

This PR does not:

- modify OrbitFabric Core
- modify OpenSVF
- modify the OpenOBSW SRDB
- merge the OrbitFabric PoC SRDB into OpenOBSW
- generate XTCE
- wire YAMCS runtime execution
- introduce Renode or hardware validation
- introduce CI
- map OrbitFabric telemetry yet

Telemetry mapping is intentionally deferred because OpenOBSW already owns native SRDB identifiers and housekeeping layout semantics.
