### PR TITLE
Add host-sim OrbitFabric event materialization

### DIFF
--- a/sim/main.c
+++ b/sim/main.c
@@ -160,10 +160,44 @@ static int fn_request_standby(const uint8_t *args, uint8_t args_len, void *ctx)
     return 0;
 }
 
+#ifdef OBSW_ENABLE_ORBITFABRIC_CONTRACT
+#define OBSW_OF_S8_FN_REPORT_VOLTAGE_OUT_OF_BOUNDS 0x5001U
+
+static int fn_of_report_voltage_out_of_bounds(const uint8_t *args,
+                                              uint8_t args_len,
+                                              void *ctx)
+{
+    (void)args;
+
+    if (args_len != 0U)
+        return -1;
+
+    int rc = obsw_s5_report((obsw_s5_ctx_t *)ctx,
+                            OBSW_S5_MEDIUM,
+                            OF_EVENT_VOLTAGE_OUT_OF_BOUNDS,
+                            NULL,
+                            0U);
+    if (rc == OBSW_PUS_TM_OK) {
+        fprintf(stderr,
+                "[OBSW] OrbitFabric: OF_EVENT_VOLTAGE_OUT_OF_BOUNDS -> TM(5,3)\n");
+        return 0;
+    }
+
+    fprintf(stderr,
+            "[OBSW] OrbitFabric: OF_EVENT_VOLTAGE_OUT_OF_BOUNDS report failed: %d\n",
+            rc);
+    return -1;
+}
+#endif
+
 static obsw_s8_entry_t s8_table[] = {
     {.function_id = OBSW_S8_FN_RECOVER_NOMINAL, .fn = fn_recover_nominal, .ctx = &fsm_ctx},
     {.function_id = OBSW_S8_FN_REQUEST_SAFE,    .fn = fn_request_safe,    .ctx = &fsm_ctx},
     {.function_id = OBSW_S8_FN_REQUEST_STANDBY, .fn = fn_request_standby, .ctx = &fsm_ctx},
+#ifdef OBSW_ENABLE_ORBITFABRIC_CONTRACT
+    {.function_id = OBSW_OF_S8_FN_REPORT_VOLTAGE_OUT_OF_BOUNDS,
+     .fn = fn_of_report_voltage_out_of_bounds, .ctx = &s5_ctx},
+#endif
 };
 
 /* ------------------------------------------------------------------------ */

--- a/sim/send_orbitfabric_event.py
+++ b/sim/send_orbitfabric_event.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+sim/send_orbitfabric_event.py — Manual OrbitFabric event materialization test.
+
+Spawns the OrbitFabric-enabled host sim, sends TC(8,1) with the host-sim
+OrbitFabric voltage-out-of-bounds function ID, and verifies that OpenOBSW
+emits TM(5,3) carrying event_id 0x5001 in the packet application data.
+
+Usage:
+    python3 sim/send_orbitfabric_event.py
+"""
+import struct
+import subprocess
+import sys
+
+
+OF_EVENT_VOLTAGE_OUT_OF_BOUNDS = 0x5001
+OBSW_OF_S8_FN_REPORT_VOLTAGE_OUT_OF_BOUNDS = 0x5001
+
+# TC(8,1) Perform Function.
+#
+# Space packet:
+#   primary header + PUS-C TC secondary header + S8 user data
+#
+# S8 user data:
+#   function_id (2 bytes BE) | args_len (1 byte)
+TC = bytes([
+    0x18, 0x01,  # primary header: version/type/sec-hdr/APID
+    0xC0, 0x00,  # sequence flags/count
+    0x00, 0x07,  # data length = 8 bytes - 1
+    0x11,        # PUS version / ack flags
+    0x08,        # service = 8
+    0x01,        # subservice = 1
+    0x00, 0x00,  # source id
+    (OBSW_OF_S8_FN_REPORT_VOLTAGE_OUT_OF_BOUNDS >> 8) & 0xFF,
+    OBSW_OF_S8_FN_REPORT_VOLTAGE_OUT_OF_BOUNDS & 0xFF,
+    0x00,        # args_len = 0
+])
+
+FRAME = b"\x01" + struct.pack(">H", len(TC)) + TC
+
+
+def parse_tm_frames(data: bytes) -> list[bytes]:
+    packets: list[bytes] = []
+    offset = 0
+
+    while offset < len(data):
+        frame_type = data[offset]
+        if frame_type == 0xFF:
+            offset += 1
+            continue
+
+        if frame_type != 0x04:
+            offset += 1
+            continue
+
+        offset += 1
+        if offset + 2 > len(data):
+            break
+
+        length = struct.unpack(">H", data[offset:offset + 2])[0]
+        offset += 2
+
+        if offset + length > len(data):
+            break
+
+        packets.append(data[offset:offset + length])
+        offset += length
+
+    return packets
+
+
+def main() -> int:
+    proc = subprocess.Popen(
+        ["./build_stage_of_event_orbitfabric/sim/obsw_sim"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    stdout, stderr = proc.communicate(input=FRAME, timeout=5)
+
+    if stderr:
+        print(stderr.decode(errors="replace").strip())
+
+    packets = parse_tm_frames(stdout)
+
+    for pkt in packets:
+        if len(pkt) < 9:
+            continue
+        svc = pkt[7]
+        subsvc = pkt[8]
+        print(f"TM({svc},{subsvc}) len={len(pkt)} raw={pkt.hex()}")
+
+    tm53 = [p for p in packets if len(p) >= 19 and p[7] == 5 and p[8] == 3]
+    if not tm53:
+        print("FAILED — no TM(5,3) packet observed")
+        return 1
+
+    pkt = tm53[0]
+    event_id = (pkt[17] << 8) | pkt[18]
+
+    if event_id != OF_EVENT_VOLTAGE_OUT_OF_BOUNDS:
+        print(
+            "FAILED — TM(5,3) event_id mismatch: "
+            f"expected 0x{OF_EVENT_VOLTAGE_OUT_OF_BOUNDS:04X}, "
+            f"got 0x{event_id:04X}"
+        )
+        return 1
+
+    print(
+        "SUCCESS — TC(8,1) triggered TM(5,3) with "
+        f"event_id 0x{event_id:04X} at raw[17:19]"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR adds the minimal host-sim-only OrbitFabric event materialization hook needed for the OpenOBSW/OpenSVF/YAMCS PoC event path.

It adds one `TC(8,1)` / PUS Service 8 function, guarded by `OBSW_ENABLE_ORBITFABRIC_CONTRACT`, which materializes:

```text
OF_EVENT_VOLTAGE_OUT_OF_BOUNDS = 0x5001
-> obsw_s5_report(OBSW_S5_MEDIUM, OF_EVENT_VOLTAGE_OUT_OF_BOUNDS, NULL, 0)
-> TM(5,3)
```

A manual host-sim check script is also added:

```text
sim/send_orbitfabric_event.py
```

The script sends the OrbitFabric S8 function trigger and verifies that OpenOBSW emits a real `TM(5,3)` carrying event id `0x5001`.

## Scope

This is intentionally limited to the OpenOBSW host simulation boundary:

- one host-sim-only S8 function ID
- one `obsw_s5_report(...)` call
- guarded by `OBSW_ENABLE_ORBITFABRIC_CONTRACT`
- no OpenSVF changes
- no flight-proper source changes
- no production FDIR changes
- no generic OrbitFabric event routing table yet
- no telemetry adapter expansion

## Runtime packet check

The manual runtime check verifies the event id in the full OpenOBSW TM packet at `raw[17:19]`:

```text
TM(5,3) raw[17] = 0x50
TM(5,3) raw[18] = 0x01
```

This corresponds to the first two bytes of the TM application data in the current OpenOBSW packet layout:

```text
6-byte CCSDS primary header
+ 11-byte PUS-C TM secondary header
+ application data
```

So the full-packet offset is `17`, while the application-data bytes themselves are `0x50 0x01`.

## Validation

Default build:

```text
cmake --build build_stage_of_event_default -j2
ctest --test-dir build_stage_of_event_default --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 18
```

OrbitFabric-enabled build:

```text
cmake --build build_stage_of_event_orbitfabric -j2
ctest --test-dir build_stage_of_event_orbitfabric --output-on-failure
```

Result:

```text
100% tests passed, 0 tests failed out of 19
```

Manual runtime check:

```text
python3 sim/send_orbitfabric_event.py
```

Result:

```text
TM(5,3) len=19 raw=0903c000000c20050300000000000000005001
SUCCESS — TC(8,1) triggered TM(5,3) with event_id 0x5001 at raw[17:19]
```

## Notes

This PR is intended as the minimal OpenOBSW-side runtime materialization step discussed in OrbitFabric-OpenOBSW-PoC Issue #26.

It enables the next PoC stage to observe a live OpenOBSW-generated `TM(5,3)` event packet through the already validated OpenSVF/YAMCS path, without adding any new OpenSVF surface.
