### PR TITLE
srdb: add generic additive composition and external build input

### DIFF
--- a/srdb/CMakeLists.txt
+++ b/srdb/CMakeLists.txt
@@ -12,14 +12,42 @@
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-set(SRDB_PKG_DIR    "${CMAKE_CURRENT_SOURCE_DIR}")
-set(SRDB_DATA_DIR   "${CMAKE_CURRENT_SOURCE_DIR}/data")
+set(SRDB_PKG_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(
+    SRDB_DATA_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/data"
+    CACHE PATH
+    "Complete SRDB data directory used by native OpenOBSW code generation"
+)
+get_filename_component(
+    SRDB_DATA_DIR
+    "${SRDB_DATA_DIR}"
+    ABSOLUTE
+    BASE_DIR "${CMAKE_SOURCE_DIR}"
+)
+
+foreach(_required_srdb_file
+        spacecraft.yaml
+        parameters.yaml
+        telecommands.yaml
+        hk_sets.yaml
+        events.yaml)
+    if(NOT EXISTS "${SRDB_DATA_DIR}/${_required_srdb_file}")
+        message(
+            FATAL_ERROR
+            "Required SRDB input file not found: ${SRDB_DATA_DIR}/${_required_srdb_file}"
+        )
+    endif()
+endforeach()
+
+message(STATUS "OpenOBSW SRDB data directory: ${SRDB_DATA_DIR}")
+
 set(SRDB_GENERATED_DIR "${CMAKE_BINARY_DIR}/include/obsw")
 set(SRDB_GENERATED_H   "${SRDB_GENERATED_DIR}/srdb_generated.h")
-set(SRDB_XTCE_DIR   "${CMAKE_BINARY_DIR}/xtce")
-set(SRDB_XTCE_FILE  "${SRDB_XTCE_DIR}/mission.xtce")
+set(SRDB_XTCE_DIR      "${CMAKE_BINARY_DIR}/xtce")
+set(SRDB_XTCE_FILE     "${SRDB_XTCE_DIR}/mission.xtce")
 
-file(GLOB SRDB_YAML_FILES "${SRDB_DATA_DIR}/*.yaml")
+file(GLOB SRDB_YAML_FILES CONFIGURE_DEPENDS "${SRDB_DATA_DIR}/*.yaml")
 
 set(_SRDB_CODEGEN_DEPS
     ${SRDB_YAML_FILES}

--- a/srdb/obsw_srdb/__init__.py
+++ b/srdb/obsw_srdb/__init__.py
@@ -5,6 +5,7 @@ from .composition import (
     SRDBCompositionError,
     SRDBContribution,
     SRDBContributionLoader,
+    SRDBMaterializer,
 )
 from .loader import SRDBLoader, SRDBValidationError
 from .model import (
@@ -25,6 +26,7 @@ __all__ = [
     "SRDBCompositionError",
     "SRDBContribution",
     "SRDBContributionLoader",
+    "SRDBMaterializer",
     "SRDB",
     "Event",
     "HKSet",

--- a/srdb/obsw_srdb/__init__.py
+++ b/srdb/obsw_srdb/__init__.py
@@ -1,5 +1,11 @@
 """obsw_srdb — openobsw Spacecraft Resource Database loader."""
 
+from .composition import (
+    SRDBComposer,
+    SRDBCompositionError,
+    SRDBContribution,
+    SRDBContributionLoader,
+)
 from .loader import SRDBLoader, SRDBValidationError
 from .model import (
     SRDB,
@@ -15,6 +21,10 @@ from .model import (
 __all__ = [
     "SRDBLoader",
     "SRDBValidationError",
+    "SRDBComposer",
+    "SRDBCompositionError",
+    "SRDBContribution",
+    "SRDBContributionLoader",
     "SRDB",
     "Event",
     "HKSet",

--- a/srdb/obsw_srdb/composition.py
+++ b/srdb/obsw_srdb/composition.py
@@ -143,3 +143,62 @@ class SRDBComposer:
                 "SRDB composition cross-reference errors:\n"
                 + "\n".join(f"  - {item}" for item in missing)
             )
+
+
+class SRDBMaterializer:
+    """Write a complete SRDB object as a normal loader-compatible data directory."""
+
+    @classmethod
+    def write(cls, srdb: SRDB, output_dir: str | Path) -> Path:
+        root = Path(output_dir)
+        if root.exists() and not root.is_dir():
+            raise SRDBCompositionError(f"SRDB output path is not a directory: {root}")
+        root.mkdir(parents=True, exist_ok=True)
+
+        documents = {
+            "spacecraft.yaml": {
+                "spacecraft": srdb.spacecraft.model_dump(mode="json", exclude_none=True)
+            },
+            "parameters.yaml": {
+                "parameters": [
+                    item.model_dump(mode="json", exclude_none=True)
+                    for item in srdb.parameters
+                ]
+            },
+            "telecommands.yaml": {
+                "telecommands": [
+                    item.model_dump(mode="json", exclude_none=True)
+                    for item in srdb.telecommands
+                ]
+            },
+            "hk_sets.yaml": {
+                "hk_sets": [
+                    item.model_dump(mode="json", exclude_none=True)
+                    for item in srdb.hk_sets
+                ]
+            },
+            "events.yaml": {
+                "events": [
+                    item.model_dump(mode="json", exclude_none=True)
+                    for item in srdb.events
+                ]
+            },
+        }
+
+        for filename, payload in documents.items():
+            (root / filename).write_text(
+                yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
+                encoding="utf-8",
+            )
+
+        # Round-trip through the canonical target loader before declaring the
+        # materialized directory valid. Import locally to keep loader ownership
+        # separate and avoid a module-level dependency cycle.
+        from .loader import SRDBLoader
+
+        reloaded = SRDBLoader.load(root)
+        if reloaded.model_dump(mode="json") != srdb.model_dump(mode="json"):
+            raise SRDBCompositionError(
+                "Materialized SRDB does not round-trip to the same logical target model"
+            )
+        return root

--- a/srdb/obsw_srdb/composition.py
+++ b/srdb/obsw_srdb/composition.py
@@ -1,0 +1,145 @@
+"""Additive composition support for externally contributed SRDB records.
+
+The composition boundary is target-owned and generic. It knows nothing about
+OrbitFabric or any other external producer: callers provide target-native
+Parameter, Telecommand, HKSet and Event records, and receive a complete
+validated SRDB while the base spacecraft record remains authoritative.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, TypeVar
+
+import yaml
+from pydantic import ValidationError
+
+from .model import Event, HKSet, Parameter, SRDB, Telecommand
+
+
+class SRDBCompositionError(ValueError):
+    """Raised when an additive SRDB contribution cannot be composed safely."""
+
+
+@dataclass(frozen=True)
+class SRDBContribution:
+    """Target-native additive records contributed to one complete base SRDB."""
+
+    parameters: tuple[Parameter, ...] = ()
+    telecommands: tuple[Telecommand, ...] = ()
+    hk_sets: tuple[HKSet, ...] = ()
+    events: tuple[Event, ...] = ()
+
+
+_ModelT = TypeVar("_ModelT", Parameter, Telecommand, HKSet, Event)
+
+
+class SRDBContributionLoader:
+    """Load one additive contribution directory into typed target records."""
+
+    FILES = {
+        "parameters": ("parameters.yaml", Parameter),
+        "telecommands": ("telecommands.yaml", Telecommand),
+        "hk_sets": ("hk_sets.yaml", HKSet),
+        "events": ("events.yaml", Event),
+    }
+
+    @classmethod
+    def load(cls, data_dir: str | Path) -> SRDBContribution:
+        root = Path(data_dir)
+        loaded: dict[str, tuple[object, ...]] = {}
+        for role, (filename, model_cls) in cls.FILES.items():
+            loaded[role] = tuple(cls._load_records(root / filename, role, model_cls))
+        return SRDBContribution(
+            parameters=loaded["parameters"],  # type: ignore[arg-type]
+            telecommands=loaded["telecommands"],  # type: ignore[arg-type]
+            hk_sets=loaded["hk_sets"],  # type: ignore[arg-type]
+            events=loaded["events"],  # type: ignore[arg-type]
+        )
+
+    @staticmethod
+    def _load_records(path: Path, key: str, model_cls: type[_ModelT]) -> list[_ModelT]:
+        if not path.is_file():
+            raise FileNotFoundError(f"Required SRDB contribution file not found: {path}")
+        try:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            raise SRDBCompositionError(f"Cannot read SRDB contribution file {path}: {exc}") from exc
+        if not isinstance(payload, dict) or not isinstance(payload.get(key), list):
+            raise SRDBCompositionError(
+                f"SRDB contribution file {path} must contain a top-level '{key}' list"
+            )
+        try:
+            return [model_cls(**record) for record in payload[key]]
+        except (TypeError, ValidationError) as exc:
+            raise SRDBCompositionError(
+                f"Invalid {key} contribution record in {path}: {exc}"
+            ) from exc
+
+
+class SRDBComposer:
+    """Compose additive target-native records into a complete validated SRDB."""
+
+    @classmethod
+    def compose(
+        cls,
+        base: SRDB,
+        contributions: Iterable[SRDBContribution],
+    ) -> SRDB:
+        parameters = [item.model_copy(deep=True) for item in base.parameters]
+        telecommands = [item.model_copy(deep=True) for item in base.telecommands]
+        hk_sets = [item.model_copy(deep=True) for item in base.hk_sets]
+        events = [item.model_copy(deep=True) for item in base.events]
+
+        for contribution in contributions:
+            parameters.extend(item.model_copy(deep=True) for item in contribution.parameters)
+            telecommands.extend(item.model_copy(deep=True) for item in contribution.telecommands)
+            hk_sets.extend(item.model_copy(deep=True) for item in contribution.hk_sets)
+            events.extend(item.model_copy(deep=True) for item in contribution.events)
+
+        cls._validate_unique(parameters, "id", "parameter ID")
+        cls._validate_unique(parameters, "name", "parameter name")
+        cls._validate_unique(events, "id", "event ID")
+        cls._validate_unique(events, "name", "event name")
+        cls._validate_unique(hk_sets, "id", "HK set ID")
+        cls._validate_unique(hk_sets, "name", "HK set name")
+        cls._validate_unique(telecommands, "name", "telecommand name")
+        cls._validate_tc_tuples(telecommands)
+        cls._validate_hk_references(parameters, hk_sets)
+
+        return SRDB(
+            spacecraft=base.spacecraft.model_copy(deep=True),
+            parameters=parameters,
+            telecommands=telecommands,
+            hk_sets=hk_sets,
+            events=events,
+        )
+
+    @staticmethod
+    def _validate_unique(records: list[object], key: str, label: str) -> None:
+        values = [getattr(record, key) for record in records]
+        if len(values) != len(set(values)):
+            raise SRDBCompositionError(f"Duplicate {label} detected during SRDB composition")
+
+    @staticmethod
+    def _validate_tc_tuples(records: list[Telecommand]) -> None:
+        tuples = [(item.apid, item.service, item.subservice) for item in records]
+        if len(tuples) != len(set(tuples)):
+            raise SRDBCompositionError(
+                "Duplicate telecommand (APID, service, subservice) tuple detected during SRDB composition"
+            )
+
+    @staticmethod
+    def _validate_hk_references(parameters: list[Parameter], hk_sets: list[HKSet]) -> None:
+        parameter_names = {item.name for item in parameters}
+        missing: list[str] = []
+        for hk_set in hk_sets:
+            for parameter_name in hk_set.parameters:
+                if parameter_name not in parameter_names:
+                    missing.append(f"HK set '{hk_set.name}' references unknown parameter '{parameter_name}'")
+        if missing:
+            raise SRDBCompositionError(
+                "SRDB composition cross-reference errors:\n"
+                + "\n".join(f"  - {item}" for item in missing)
+            )

--- a/srdb/tests/test_composition.py
+++ b/srdb/tests/test_composition.py
@@ -1,0 +1,221 @@
+"""Tests for the generic additive SRDB composition boundary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from obsw_srdb import (
+    Event,
+    HKSet,
+    Parameter,
+    SRDBComposer,
+    SRDBCompositionError,
+    SRDBContribution,
+    SRDBContributionLoader,
+    Telecommand,
+)
+
+
+def parameter(identifier: int = 0x6001, name: str = "external_voltage_mv") -> Parameter:
+    return Parameter(
+        id=identifier,
+        name=name,
+        description="External voltage",
+        type="uint16",
+        ptc=1,
+        pfc=16,
+        unit="mV",
+    )
+
+
+def event(identifier: int = 0x5001, name: str = "external_voltage_event") -> Event:
+    return Event(
+        id=identifier,
+        name=name,
+        severity="MEDIUM",
+        description="External voltage event",
+        safe_trigger=False,
+        auxiliary_data=[],
+    )
+
+
+def hk_set(identifier: int = 5, name: str = "external_hk", parameter_name: str = "external_voltage_mv") -> HKSet:
+    return HKSet(
+        id=identifier,
+        name=name,
+        description="External housekeeping",
+        parameters=[parameter_name],
+        default_interval_ticks=0,
+    )
+
+
+def telecommand(
+    name: str = "external_command",
+    apid: int = 16,
+    service: int = 99,
+    subservice: int = 1,
+) -> Telecommand:
+    return Telecommand(
+        name=name,
+        description="External command",
+        apid=apid,
+        service=service,
+        subservice=subservice,
+        parameters=[],
+    )
+
+
+def write_contribution(root: Path) -> None:
+    records = {
+        "parameters": [parameter().model_dump(mode="json")],
+        "telecommands": [telecommand().model_dump(mode="json")],
+        "hk_sets": [hk_set().model_dump(mode="json")],
+        "events": [event().model_dump(mode="json")],
+    }
+    for role, items in records.items():
+        (root / f"{role}.yaml").write_text(
+            yaml.safe_dump({role: items}, sort_keys=False),
+            encoding="utf-8",
+        )
+
+
+def test_load_contribution_and_compose_without_mutating_base(srdb, tmp_path: Path) -> None:
+    write_contribution(tmp_path)
+    contribution = SRDBContributionLoader.load(tmp_path)
+
+    base_counts = (
+        len(srdb.parameters),
+        len(srdb.telecommands),
+        len(srdb.hk_sets),
+        len(srdb.events),
+    )
+    composed = SRDBComposer.compose(srdb, [contribution])
+
+    assert base_counts == (
+        len(srdb.parameters),
+        len(srdb.telecommands),
+        len(srdb.hk_sets),
+        len(srdb.events),
+    )
+    assert len(composed.parameters) == base_counts[0] + 1
+    assert len(composed.telecommands) == base_counts[1] + 1
+    assert len(composed.hk_sets) == base_counts[2] + 1
+    assert len(composed.events) == base_counts[3] + 1
+    assert composed.parameter_by_id(0x6001).name == "external_voltage_mv"
+    assert composed.hk_set_by_id(5).parameters == ["external_voltage_mv"]
+    assert composed.event_by_id(0x5001).name == "external_voltage_event"
+    assert composed.spacecraft == srdb.spacecraft
+    assert composed.spacecraft is not srdb.spacecraft
+
+
+def test_empty_contribution_is_logical_noop(srdb) -> None:
+    composed = SRDBComposer.compose(srdb, [SRDBContribution()])
+    assert composed == srdb
+    assert composed is not srdb
+
+
+def test_parameter_id_collision_is_rejected(srdb) -> None:
+    existing = srdb.parameters[0]
+    contribution = SRDBContribution(
+        parameters=(parameter(existing.id, "different_external_parameter"),)
+    )
+    with pytest.raises(SRDBCompositionError, match="Duplicate parameter ID"):
+        SRDBComposer.compose(srdb, [contribution])
+
+
+def test_parameter_name_collision_is_rejected(srdb) -> None:
+    existing = srdb.parameters[0]
+    contribution = SRDBContribution(parameters=(parameter(0x6001, existing.name),))
+    with pytest.raises(SRDBCompositionError, match="Duplicate parameter name"):
+        SRDBComposer.compose(srdb, [contribution])
+
+
+def test_event_id_and_name_collisions_are_rejected(srdb) -> None:
+    existing = srdb.events[0]
+    with pytest.raises(SRDBCompositionError, match="Duplicate event ID"):
+        SRDBComposer.compose(
+            srdb,
+            [SRDBContribution(events=(event(existing.id, "different_external_event"),))],
+        )
+    with pytest.raises(SRDBCompositionError, match="Duplicate event name"):
+        SRDBComposer.compose(
+            srdb,
+            [SRDBContribution(events=(event(0x5001, existing.name),))],
+        )
+
+
+def test_hk_id_and_name_collisions_are_rejected(srdb) -> None:
+    existing = srdb.hk_sets[0]
+    with pytest.raises(SRDBCompositionError, match="Duplicate HK set ID"):
+        SRDBComposer.compose(
+            srdb,
+            [SRDBContribution(hk_sets=(hk_set(existing.id, "different_external_hk", srdb.parameters[0].name),))],
+        )
+    with pytest.raises(SRDBCompositionError, match="Duplicate HK set name"):
+        SRDBComposer.compose(
+            srdb,
+            [SRDBContribution(hk_sets=(hk_set(5, existing.name, srdb.parameters[0].name),))],
+        )
+
+
+def test_telecommand_tuple_and_name_collisions_are_rejected(srdb) -> None:
+    existing = srdb.telecommands[0]
+    with pytest.raises(SRDBCompositionError, match="Duplicate telecommand .* tuple"):
+        SRDBComposer.compose(
+            srdb,
+            [
+                SRDBContribution(
+                    telecommands=(
+                        telecommand(
+                            "different_external_command",
+                            existing.apid,
+                            existing.service,
+                            existing.subservice,
+                        ),
+                    )
+                )
+            ],
+        )
+    with pytest.raises(SRDBCompositionError, match="Duplicate telecommand name"):
+        SRDBComposer.compose(
+            srdb,
+            [SRDBContribution(telecommands=(telecommand(existing.name),))],
+        )
+
+
+def test_unknown_hk_parameter_reference_is_rejected(srdb) -> None:
+    contribution = SRDBContribution(
+        hk_sets=(hk_set(parameter_name="does_not_exist"),)
+    )
+    with pytest.raises(SRDBCompositionError, match="references unknown parameter 'does_not_exist'"):
+        SRDBComposer.compose(srdb, [contribution])
+
+
+def test_contributed_hk_can_reference_contributed_parameter(srdb) -> None:
+    contribution = SRDBContribution(
+        parameters=(parameter(),),
+        hk_sets=(hk_set(),),
+    )
+    composed = SRDBComposer.compose(srdb, [contribution])
+    assert composed.hk_set_by_id(5).parameters == ["external_voltage_mv"]
+
+
+def test_loader_requires_explicit_target_files(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="parameters.yaml"):
+        SRDBContributionLoader.load(tmp_path)
+
+
+def test_loader_rejects_invalid_target_record(tmp_path: Path) -> None:
+    for role in ("parameters", "telecommands", "hk_sets", "events"):
+        items = []
+        if role == "parameters":
+            items = [{"id": 0x6001, "name": "bad", "description": "missing type"}]
+        (tmp_path / f"{role}.yaml").write_text(
+            yaml.safe_dump({role: items}, sort_keys=False),
+            encoding="utf-8",
+        )
+    with pytest.raises(SRDBCompositionError, match="Invalid parameters contribution record"):
+        SRDBContributionLoader.load(tmp_path)

--- a/srdb/tests/test_materialization.py
+++ b/srdb/tests/test_materialization.py
@@ -1,0 +1,66 @@
+"""Tests for complete SRDB materialization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from obsw_srdb import (
+    HKSet,
+    Parameter,
+    SRDBComposer,
+    SRDBContribution,
+    SRDBLoader,
+    SRDBMaterializer,
+)
+
+
+def test_materialized_complete_srdb_round_trips(srdb, tmp_path: Path) -> None:
+    contribution = SRDBContribution(
+        parameters=(
+            Parameter(
+                id=0x6001,
+                name="external_voltage_mv",
+                description="External voltage",
+                type="uint16",
+                ptc=1,
+                pfc=16,
+                unit="mV",
+            ),
+        ),
+        hk_sets=(
+            HKSet(
+                id=5,
+                name="external_hk",
+                description="External housekeeping",
+                parameters=["external_voltage_mv"],
+                default_interval_ticks=0,
+            ),
+        ),
+    )
+    composed = SRDBComposer.compose(srdb, [contribution])
+
+    output = SRDBMaterializer.write(composed, tmp_path / "assembled")
+    reloaded = SRDBLoader.load(output)
+
+    assert reloaded == composed
+    assert reloaded.parameter_by_id(0x6001).name == "external_voltage_mv"
+    assert reloaded.hk_set_by_id(5).parameters == ["external_voltage_mv"]
+
+
+def test_materialization_writes_only_complete_srdb_contract_files(srdb, tmp_path: Path) -> None:
+    output = SRDBMaterializer.write(srdb, tmp_path / "assembled")
+    assert {path.name for path in output.iterdir()} == {
+        "spacecraft.yaml",
+        "parameters.yaml",
+        "telecommands.yaml",
+        "hk_sets.yaml",
+        "events.yaml",
+    }
+
+
+def test_materialization_is_byte_stable_for_same_model(srdb, tmp_path: Path) -> None:
+    first = SRDBMaterializer.write(srdb, tmp_path / "first")
+    second = SRDBMaterializer.write(srdb, tmp_path / "second")
+
+    for filename in SRDBLoader.REQUIRED_FILES:
+        assert (first / filename).read_bytes() == (second / filename).read_bytes()


### PR DESCRIPTION
## Summary

This PR adds a generic, target-owned boundary for composing externally contributed `obsw-srdb` records into a complete SRDB and using that assembled database as an explicit OpenOBSW code-generation input.

The implementation is intentionally producer-agnostic: `obsw-srdb` owns the target models, collision rules, cross-reference validation, materialization format, and build-time consumption. External producers only provide target-native additive records.

## What this adds

### 1. Additive SRDB contribution model

Adds:

- `SRDBContribution`
- `SRDBContributionLoader`
- `SRDBComposer`
- `SRDBCompositionError`

A contribution contains target-native:

- parameters
- telecommands
- housekeeping sets
- events

Composition is additive-only. The base SRDB remains authoritative, including the spacecraft record.

### 2. Explicit composition safety rules

Composition rejects ambiguous or conflicting target data, including:

- duplicate parameter IDs
- duplicate parameter names
- duplicate event IDs
- duplicate event names
- duplicate HK set IDs
- duplicate HK set names
- duplicate telecommand names
- duplicate telecommand `(APID, service, subservice)` tuples
- HK references to unknown parameters

The base SRDB is deep-copied and is not mutated by composition.

### 3. Complete SRDB materialization

Adds `SRDBMaterializer`, which writes a composed `SRDB` back to the canonical loader-compatible directory contract:

```text
spacecraft.yaml
parameters.yaml
telecommands.yaml
hk_sets.yaml
events.yaml
```

Materialization is validated by round-tripping the generated directory through the canonical `SRDBLoader`.

For the same logical SRDB model, materialization is byte-stable.

### 4. External SRDB input for native OpenOBSW code generation

`srdb/CMakeLists.txt` now exposes:

```cmake
SRDB_DATA_DIR
```

as a `CACHE PATH`.

The existing in-tree database remains the default:

```text
srdb/data
```

so current builds keep the existing behavior unchanged.

A caller may instead configure OpenOBSW with a complete external SRDB:

```bash
cmake -S . -B build \
  -DSRDB_DATA_DIR=/path/to/assembled_srdb
```

The native `srdb_codegen` target then produces the usual:

```text
srdb_generated.h
mission.xtce
```

from that external database.

CMake also checks that the complete required SRDB file set exists before code generation starts.

## Why

Until now, the native OpenOBSW code-generation path was directly tied to the repository-owned `srdb/data` directory.

That works well for the built-in database, but makes downstream composition awkward: an external mission-data producer has to copy or patch files into the source checkout before OpenOBSW can consume them.

This PR makes the ownership boundary explicit:

```text
external producer
      ↓
target-native additive records
      ↓
obsw-srdb composition
      ↓
complete validated SRDB
      ↓
external SRDB_DATA_DIR
      ↓
native OpenOBSW code generation
```

The external producer does not own SRDB merge semantics, and OpenOBSW does not need to know which producer generated the contribution.

## Tests

Focused target-side tests:

```text
14 passed
```

Coverage includes:

- contribution loading
- base immutability
- empty contribution behavior
- all ID/name collision classes
- telecommand tuple collisions
- HK cross-reference validation
- contributed HK → contributed parameter references
- invalid contribution record rejection
- complete SRDB round-trip
- canonical output file set
- deterministic byte-stable materialization

## Downstream validation

The new boundary has also been exercised from an external integration harness using a real generated additive contribution.

That validation demonstrated:

```text
base SRDB + external contribution
        ↓
complete target-owned SRDB
        ↓
external SRDB_DATA_DIR
        ↓
native OpenOBSW srdb_codegen
        ↓
C header + XTCE
```

and then a full `obsw_sim` build/runtime using the same externally assembled database, without modifying the repository-owned `srdb/data`.

This downstream validation is evidence for the boundary; it is not a dependency of this PR.

## Scope

This PR does **not**:

- add OrbitFabric-specific semantics to `obsw-srdb`
- define an external producer format beyond the existing target-native YAML records
- allow overriding/replacing existing SRDB records
- mutate `srdb/data`
- change the default SRDB used by existing builds
- change OpenOBSW runtime dispatch semantics
- add OpenSVF-specific behavior

## Architectural intent

The intended ownership split is:

```text
producer owns mission-to-target projection
          ↓
obsw-srdb owns target composition semantics
          ↓
OpenOBSW owns native code generation and build consumption
```

This keeps external integration additive while preserving OpenOBSW as the authority for its own SRDB model and validation rules.