### PR TITLE
B-dot dB/dt high-pass filter for orbital aliasing (#70)

### DIFF
--- a/docs/issue-70-opensvf-kde-handoff.md
+++ b/docs/issue-70-opensvf-kde-handoff.md
@@ -1,0 +1,205 @@
+# Issue #70 — B-dot orbital aliasing: opensvf-kde validation handoff
+
+**Status:** fix implemented and bench-validated in openobsw; needs a run against
+the opensvf-kde `OrbitalEnvironment` model to formally close and lift the
+`bdot_gain` freeze.
+
+**openobsw branch:** `fix/70-bdot-hpf-orbital-aliasing` — commits `dede8c0`
+(HPF) and `d594d31` (τ tuning + S20 registration + bench harness).
+
+---
+
+## 1. The bug
+
+`obsw_bdot_step()` (`src/aocs/bdot.c`) estimates the field derivative by raw
+finite difference:
+
+```
+dB/dt ≈ (B_k − B_{k-1}) / dt
+```
+
+Under opensvf-kde's `OrbitalEnvironment`, the body-frame magnetometer reading
+changes as the spacecraft travels along its orbit **even at zero attitude
+rate** — the geomagnetic field has a spatial gradient. The finite-difference
+estimator cannot tell "the field changed because I rotated" from "the field
+changed because I moved 50 km along-track". The orbital component aliases into
+a non-zero `dB/dt`, so B-dot commands a spurious dipole forever and never
+quiesces.
+
+Measured baseline (opensvf-kde, null attitude):
+`|dB/dt| ≈ 4.11e-08 T/s → |m_cmd| ≈ 4.11e-04 Am²` with zero tumble.
+The KDE/FMU path did **not** show this (B held constant for a null pass) —
+aliasing is specific to the `OrbitalEnvironment` spatial model.
+
+---
+
+## 2. The fix
+
+First-order washout (high-pass) on the `dB/dt` estimate, applied before the
+B-dot gain:
+
+```
+y[k] = α · (y[k-1] + x[k] − x[k-1])          α = τ / (τ + dt)
+```
+
+- `x[k]` = raw finite-difference `dB/dt`, `y[k]` = filtered `dB/dt`
+- DC (the orbital gradient, ~1.7e-4 Hz at 550 km) → 0 in steady state
+- attitude-tumble content (≫ corner frequency) passes with ~unity gain
+- `τ = 0` disables the filter (`y = x`), preserving the original behaviour
+
+Implemented in `obsw_bdot_step()`; state carried in `obsw_bdot_ctx_t`
+(`dbdt_raw_prev`, `dbdt_filt`). Output struct `obsw_bdot_output_t` now carries
+both `dbdt[3]` (raw) and `dbdt_filt[3]` (filtered) for telemetry/diagnostics.
+
+### Parameter
+
+| Field | Value |
+|---|---|
+| SRDB name | `bdot_hpf_tau` |
+| SRDB id | `0x20A3` |
+| Type | `float32`, seconds |
+| Default | **15 s** |
+| Disable | `0` |
+| Limits | `soft_low: 0.0` |
+| Path | `srdb/data/parameters.yaml` → generated `SRDB_PARAM_BDOT_HPF_TAU` |
+
+Registered in the S20 tables of both `sim/main.c` and `src/task/pus.c`, so
+ground can retune it live with `TC(20,1)` on `0x20A3` and read it with
+`TC(20,3)`. Re-synced from the S20 store into `bdot_ctx.config.hpf_tau` on
+every control tick (host: `sim/main.c`; flight: `src/task/aocs.c`).
+
+### Why τ = 15 s
+
+The washout coefficient `α = τ/(τ+dt)` → 1 as τ grows, so an over-large τ
+degrades the filter toward passthrough. Bench sweep (see §4) — steady-state
+spurious `|m_cmd|` rejection vs `τ=0`:
+
+| τ (s) | rejection | detumble convergence (ω₀ = 0.3 rad/s) |
+|------:|----------:|--------------------------------------:|
+| 15 | **8.9×** | 0.35 orbits |
+| 30 | 5.9× | 0.25 orbits |
+| 60 | 5.0× | — |
+
+τ = 15 s gives the best artifact rejection at negligible detumble cost. This
+default may want revisiting for a different orbit altitude / `dt`; that is
+exactly what the opensvf-kde run should check.
+
+---
+
+## 3. What to run on opensvf-kde
+
+Reproduce the openobsw bench (`sim/bdot_hpf_validation.py`) but feed the
+magnetometer from the real `OrbitalEnvironment` instead of the built-in
+geocentric-dipole model. Two checks:
+
+### Check A — orbital-aliasing rejection (null attitude)
+
+- Hold attitude fixed (or start from rest), `ω₀ = 0`.
+- Let `OrbitalEnvironment` drive `B_body(t)` over ≥ 2 orbits.
+- Sweep `bdot_hpf_tau ∈ {0, 15, 30}` via `TC(20,1)`.
+- **Pass:** at the chosen τ, steady-state `|m_cmd|` (mean over the last orbit)
+  drops ≥ 5× vs τ=0 **and** the from-rest spurious `|ω|` peak stays
+  < 5e-3 rad/s. Expect `|m_cmd|` to fall from ~4.11e-4 Am² toward ~5e-5 Am²
+  or below.
+
+### Check B — detumble still works
+
+- Full rigid-body dynamics, `ω₀ = (0.3, 0.3, 0.3) rad/s`, chosen τ.
+- **Pass:** `|ω| < 0.05 rad/s` within 3 orbital periods.
+
+### Wire protocol (v3, framed pipe — stdin/stdout of `obsw_sim`)
+
+```
+→ OBSW  0x01 [u16 BE len] [TC space-packet bytes]       TC uplink
+→ OBSW  0x02 [u16 BE len] [obsw_sensor_frame_t]         Sensor injection
+← OBSW  0x03 [u16 BE len] [obsw_actuator_frame_t]       Actuator output
+← OBSW  0x04 [u16 BE len] [TM packet bytes]             TM downlink
+← OBSW  0xFF                                            End of tick
+```
+
+- `obsw_sensor_frame_t` — 47 B packed LE, `struct '<fffBffffBfffBf'`:
+  MAG xyz + valid, ST quat wxyz + valid, GYRO xyz + valid, sim_time.
+  For B-dot only MAG xyz + `mag_valid=1` matter; set ST/GYRO valid = 0.
+- `obsw_actuator_frame_t` — 29 B packed LE, `struct '<ffffffBf'`:
+  MTQ dipole xyz, RW torque xyz, controller byte, sim_time.
+  B-dot output is `mtq_dipole_{x,y,z}`; `controller` byte = 0 in SAFE.
+- **Set `bdot_hpf_tau`:** `TC(20,1)`, app data = `>H` param_id (`0x20A3`) then
+  `>f` value (IEEE-754 BE). Build with `build_tc(APID, 20, 1, payload)` and
+  `send_tc`; drain the response with `drain_tc_response`. Helpers in
+  `sim/wire_proto.py`.
+- The sim boots in **SAFE**, so B-dot is active with no mode TC needed.
+- `obsw_sim` also logs per SAFE tick to stderr:
+  `[OBSW] bdot raw=[…] |raw|=… filt=[…] |filt|=… m=[…] Am2` — capture this
+  for the before/after comparison.
+
+### Reference harness
+
+`sim/bdot_hpf_validation.py` in this branch. Structure to reuse:
+`run_aliasing()` / `run_detumble()` step the loop, `set_hpf_tau()` sends the
+TC(20,1). Replace the `orbit_position()` / `igrf_dipole_eci()` calls with the
+`OrbitalEnvironment` B-field lookup for the current sim time and
+spacecraft position. `sim/bdot_harness.py` is the existing closed-loop
+convergence harness and reads orbit/inertia config from S20 via `TC(20,3)`.
+
+---
+
+## 4. openobsw bench result (geocentric-dipole model, NOT KDE)
+
+550 km SSO, inc 97.4°, `dt = 0.1 s`:
+
+```
+== Check A: spurious spin-up from rest ==
+  tau=  0.0 s : peak|ω|=2.911e-03 rad/s   mean spurious|m_cmd|=1.871e-04 Am²
+  tau= 15.0 s : peak|ω|=2.848e-04 rad/s   mean spurious|m_cmd|=2.098e-05 Am²  (8.9x)
+  tau= 30.0 s : peak|ω|=5.743e-04 rad/s   mean spurious|m_cmd|=3.148e-05 Am²  (5.9x)
+  tau= 60.0 s : peak|ω|=9.637e-04 rad/s   mean spurious|m_cmd|=3.770e-05 Am²  (5.0x)
+== Check B: detumble (ω0=0.3,0.3,0.3, tau=15) ==
+  converged at t=1994 s (0.35 orbital periods)  |ω|=0.0500 rad/s
+PASS
+```
+
+The dipole bench's τ=0 spin-up already stays sub-threshold (2.9e-3 rad/s) —
+the KDE model's steeper gradient is where the filter matters more, so the KDE
+run is the one that counts.
+
+---
+
+## 5. After the opensvf-kde run passes
+
+1. If the KDE run suggests a different τ, update the default in
+   `srdb/data/parameters.yaml` (`0x20A3` description) and every code fallback
+   (`sim/main.c` ×3, `src/task/aocs.c` ×2, `src/task/pus.c` ×1). `grep -rn
+   BDOT_HPF_TAU` finds them all.
+2. Lift the `bdot_gain` (`0x20A0`) retune freeze — remove the warning from
+   `CLAUDE.md` "Open Issues" and close #70.
+3. Full OpenSVF closed-loop integration test (YAMCS in the loop): confirm
+   `bdot_hpf_tau` shows up as an XTCE parameter, is settable from the ground
+   segment, and that a tumbling→detumbled campaign run stays nominal.
+
+---
+
+## 6. OrbitFabric contract sync (PoC point 4)
+
+`bdot_hpf_tau` is currently defined only in `srdb/data/parameters.yaml`. Per
+the #70 constraint it should be a contract-defined item so the generated
+flight header and `parameters.yaml` agree. Add to
+`orbitfabric_models/` in `lipofefeyt/OrbitFabric-OpenOBSW-PoC`:
+
+```yaml
+# parameter
+name: bdot_hpf_tau
+id: 0x20A3
+type: float32
+unit: s
+default: 15.0
+limits: { soft_low: 0.0 }
+description: >
+  B-dot HPF time constant. First-order high-pass on the dB/dt estimate that
+  rejects orbital-rate field variation while passing attitude-rate content.
+  0 disables. Bench default 15 s (550 km SSO); confirm against opensvf-kde.
+subsystem: AOCS/Control
+```
+
+Then regenerate `generated_artifacts/flight_software/mission_contract.h` and
+`generated_artifacts/ground_segment/*.xtce` and diff against openobsw's
+`build/include/obsw/srdb_generated.h` / `build/xtce/mission.xtce`.

--- a/include/obsw/aocs/bdot.h
+++ b/include/obsw/aocs/bdot.h
@@ -39,6 +39,8 @@ extern "C" {
 typedef struct {
     float gain;       /**< Controller gain k [A·m²·s/T]           */
     float max_dipole; /**< Saturation limit [A·m²]                 */
+    float hpf_tau;    /**< HPF time constant τ [s]; 0 = disabled.
+                           Rejects orbital-rate dB/dt (issue #70). */
 } obsw_bdot_config_t;
 
 /* ------------------------------------------------------------------ */
@@ -47,8 +49,10 @@ typedef struct {
 
 typedef struct {
     obsw_bdot_config_t config;
-    float b_prev[3];  /**< Previous B-field measurement [T]        */
-    bool initialised; /**< True after first measurement            */
+    float b_prev[3];      /**< Previous B-field measurement [T]    */
+    float dbdt_raw_prev[3]; /**< Previous raw dB/dt [T/s] — HPF x[k-1] */
+    float dbdt_filt[3];   /**< HPF output state y[k-1] [T/s]       */
+    bool initialised;     /**< True after first measurement         */
 } obsw_bdot_ctx_t;
 
 /* ------------------------------------------------------------------ */
@@ -56,8 +60,10 @@ typedef struct {
 /* ------------------------------------------------------------------ */
 
 typedef struct {
-    float m_cmd[3]; /**< Dipole command [A·m²] (x, y, z)        */
-    float dbdt[3];  /**< Estimated dB/dt [T/s]                   */
+    float m_cmd[3];      /**< Dipole command [A·m²] (x, y, z)     */
+    float dbdt[3];       /**< Raw estimated dB/dt [T/s]            */
+    float dbdt_filt[3];  /**< HPF-filtered dB/dt [T/s]; equals
+                              dbdt[] when HPF is disabled           */
 } obsw_bdot_output_t;
 
 /* ------------------------------------------------------------------ */

--- a/sim/bdot_hpf_validation.py
+++ b/sim/bdot_hpf_validation.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+sim/bdot_hpf_validation.py — Issue #70 closed-loop validation.
+
+Two checks against a running obsw_sim (SAFE mode, wire protocol v3):
+
+  A) Orbital-aliasing rejection (spurious spin-up)
+     Full rigid-body dynamics started from rest (q=[1,0,0,0], ω=0).  The only
+     dB/dt the magnetometer sees is the orbital field gradient.  With
+     bdot_hpf_tau=0 the finite-difference estimator aliases it into a spurious
+     dipole that random-walks the body rate up.  Sweep tau and measure the
+     peak |ω| reached over 2 orbits, plus the mean spurious |m_cmd|.
+     Pass (for the chosen tau): peak |ω| < 5e-3 rad/s  (10% of the detumble
+     threshold) AND >= 10x lower than the tau=0 case.
+
+  B) Detumble still works
+     Full rigid-body dynamics, ω0 = (0.3, 0.3, 0.3) rad/s, chosen tau.
+     Pass: |ω| < 0.05 rad/s within 3 orbital periods.
+
+Usage:
+  source .venv/bin/activate
+  python3 sim/bdot_hpf_validation.py [--sim PATH] [--dt DT]
+"""
+
+import argparse
+import math
+import os
+import struct
+import subprocess
+import sys
+
+import numpy as np
+
+from wire_proto import (
+    build_tc, send_tc, drain_tc_response,
+    send_sensor, recv_tick,
+    quat_step, omega_step,
+    APID_DEFAULT,
+)
+
+SRDB_BDOT_HPF_TAU = 0x20A3
+SRDB_BDOT_GAIN    = 0x20A0
+
+MU_EARTH = 3.986004418e14
+R_EARTH  = 6.371e6
+B0_SURF  = 3.12e-5
+
+ALT_KM   = 550.0
+INC_DEG  = 97.4
+I_DIAG   = np.array([2.0e-3, 2.5e-3, 1.5e-3])
+
+PASS_OMEGA        = 0.05     # rad/s  — detumble convergence threshold
+SPINUP_ABS_LIMIT  = 5.0e-3   # rad/s  — spurious peak |ω| must stay this far below PASS_OMEGA
+MCMD_REJECT_X     = 5.0      # steady-state spurious |m_cmd| must drop >= this factor vs tau=0
+TAU_SWEEP         = [0.0, 15.0, 30.0, 60.0]
+TAU_CHOSEN        = 15.0
+
+
+def orbit_position(t, r_orbit, inc_rad):
+    n = math.sqrt(MU_EARTH / r_orbit**3)
+    nu = n * t
+    return r_orbit * np.array([
+        math.cos(nu),
+        math.sin(nu) * math.cos(inc_rad),
+        math.sin(nu) * math.sin(inc_rad),
+    ])
+
+
+def igrf_dipole_eci(r_eci):
+    r_mag = np.linalg.norm(r_eci)
+    r_hat = r_eci / r_mag
+    m_hat = np.array([0.0, 0.0, -1.0])
+    scale = B0_SURF * (R_EARTH / r_mag) ** 3
+    return scale * (3.0 * np.dot(m_hat, r_hat) * r_hat - m_hat)
+
+
+def quat_rot_matrix(q):
+    w, x, y, z = q
+    return np.array([
+        [1 - 2*(y*y + z*z),   2*(x*y - w*z),     2*(x*z + w*y)],
+        [    2*(x*y + w*z), 1 - 2*(x*x + z*z),   2*(y*z - w*x)],
+        [    2*(x*z - w*y),     2*(y*z + w*x), 1 - 2*(x*x + y*y)],
+    ])
+
+
+def set_hpf_tau(proc, tau):
+    payload = struct.pack('>H', SRDB_BDOT_HPF_TAU) + struct.pack('>f', float(tau))
+    send_tc(proc, build_tc(APID_DEFAULT, 20, 1, payload))
+    drain_tc_response(proc)
+
+
+def start_sim(sim_path):
+    return subprocess.Popen(
+        [sim_path],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+    )
+
+
+def run_aliasing(sim_path, dt, tau, n_steps, r_orbit, inc_rad):
+    """Full dynamics from rest. Return (peak|ω|, mean spurious |m_cmd| over 2nd half)."""
+    proc = start_sim(sim_path)
+    try:
+        set_hpf_tau(proc, tau)
+        I     = np.diag(I_DIAG)
+        I_inv = np.linalg.inv(I)
+        q     = np.array([1.0, 0.0, 0.0, 0.0])
+        omega = np.zeros(3)
+        peak_w = 0.0
+        m_tail = []
+        half   = n_steps // 2
+        for k in range(n_steps):
+            t = k * dt
+            r_eci  = orbit_position(t, r_orbit, inc_rad)
+            B_body = quat_rot_matrix(q).T @ igrf_dipole_eci(r_eci)
+            send_sensor(proc, B_body, q, omega, t, st_valid=0, gyro_valid=0)
+            act = recv_tick(proc)
+            tau_vec = np.cross(act.mtq, B_body)
+            omega   = omega_step(omega, tau_vec, I, I_inv, dt)
+            q       = quat_step(q, omega, dt)
+            peak_w  = max(peak_w, float(np.linalg.norm(omega)))
+            if k >= half:
+                m_tail.append(float(np.linalg.norm(act.mtq)))
+        return peak_w, float(np.mean(m_tail))
+    finally:
+        proc.stdin.close()
+        proc.wait()
+
+
+def run_detumble(sim_path, dt, tau, max_periods, r_orbit, inc_rad, T_orbit):
+    proc = start_sim(sim_path)
+    try:
+        set_hpf_tau(proc, tau)
+        I     = np.diag(I_DIAG)
+        I_inv = np.linalg.inv(I)
+        omega = np.array([0.3, 0.3, 0.3])
+        q     = np.array([1.0, 0.0, 0.0, 0.0])
+        t     = 0.0
+        max_t = max_periods * T_orbit
+        while t <= max_t:
+            r_eci  = orbit_position(t, r_orbit, inc_rad)
+            B_body = quat_rot_matrix(q).T @ igrf_dipole_eci(r_eci)
+            send_sensor(proc, B_body, q, omega, t, st_valid=0, gyro_valid=0)
+            act = recv_tick(proc)
+            tau_vec = np.cross(act.mtq, B_body)
+            omega   = omega_step(omega, tau_vec, I, I_inv, dt)
+            q       = quat_step(q, omega, dt)
+            t      += dt
+            if np.linalg.norm(omega) < PASS_OMEGA:
+                return t, t / T_orbit, float(np.linalg.norm(omega))
+        return None, t / T_orbit, float(np.linalg.norm(omega))
+    finally:
+        proc.stdin.close()
+        proc.wait()
+
+
+def main():
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--sim', default=os.path.join(repo, 'build', 'sim', 'obsw_sim'))
+    ap.add_argument('--dt', type=float, default=0.1)
+    ap.add_argument('--orbits', type=float, default=2.0,
+                    help='orbits for the check-A spin-up runs')
+    ap.add_argument('--tau-sweep', default=None,
+                    help='comma-separated tau values for check A (overrides default)')
+    ap.add_argument('--tau-chosen', type=float, default=None,
+                    help='tau used for the pass verdict and check B')
+    args = ap.parse_args()
+
+    tau_sweep  = ([float(x) for x in args.tau_sweep.split(',')]
+                  if args.tau_sweep else list(TAU_SWEEP))
+    tau_chosen = args.tau_chosen if args.tau_chosen is not None else TAU_CHOSEN
+    if tau_chosen not in tau_sweep:
+        tau_sweep.append(tau_chosen)
+
+    if not os.path.exists(args.sim):
+        print(f'ERROR: sim binary not found: {args.sim}')
+        return 2
+
+    r_orbit = R_EARTH + ALT_KM * 1e3
+    T_orbit = 2.0 * math.pi * math.sqrt(r_orbit**3 / MU_EARTH)
+    inc_rad = math.radians(INC_DEG)
+    n_steps = int(args.orbits * T_orbit / args.dt)
+
+    print(f'Orbit: alt={ALT_KM:.0f} km  inc={INC_DEG}°  T={T_orbit:.0f} s')
+    print(f'dt={args.dt}s   aliasing run = {n_steps} steps ({args.orbits:g} orbits)')
+    print(f'tau sweep = {tau_sweep}   chosen = {tau_chosen:g} s\n')
+
+    print('== Check A: orbital-aliasing rejection — spurious spin-up from rest ==')
+    results = {}
+    for tau in tau_sweep:
+        peak_w, mean_m = run_aliasing(args.sim, args.dt, tau, n_steps, r_orbit, inc_rad)
+        results[tau] = (peak_w, mean_m)
+        print(f'  tau={tau:5.1f} s : peak|ω|={peak_w:.3e} rad/s   '
+              f'mean spurious|m_cmd|={mean_m:.3e} Am²')
+
+    peak0, mean0 = results.get(0.0, (None, None))
+    peak_c, mean_c = results[tau_chosen]
+    m_factor = (mean0 / mean_c) if (mean0 and mean_c > 0) else float('nan')
+    print(f'\n  chosen tau={tau_chosen:g} s:')
+    print(f'    spurious |m_cmd|  : {mean_c:.3e} Am²' +
+          (f'  ({m_factor:.1f}x below tau=0, need >= {MCMD_REJECT_X:.0f}x)'
+           if mean0 else ''))
+    print(f'    spin-up peak |ω|  : {peak_c:.3e} rad/s  '
+          f'(limit {SPINUP_ABS_LIMIT:.0e})')
+    check_a = peak_c < SPINUP_ABS_LIMIT and (not mean0 or m_factor >= MCMD_REJECT_X)
+    print(f'  {"PASS" if check_a else "FAIL"}\n')
+
+    print(f'== Check B: detumble still converges (ω0=0.3,0.3,0.3  tau={tau_chosen:g}) ==')
+    t_conv, p_conv, w_final = run_detumble(
+        args.sim, args.dt, tau_chosen, 3.0, r_orbit, inc_rad, T_orbit)
+    if t_conv is not None:
+        print(f'  converged at t={t_conv:.0f} s ({p_conv:.2f} orbital periods)  '
+              f'|ω|={w_final:.4f} rad/s')
+        check_b = True
+    else:
+        print(f'  did NOT converge: |ω|={w_final:.4f} rad/s after {p_conv:.2f} periods')
+        check_b = False
+    print(f'  {"PASS" if check_b else "FAIL"}\n')
+
+    ok = check_a and check_b
+    print('=' * 60)
+    if ok:
+        print('ISSUE #70 BENCH VALIDATION: PASS')
+        print('  HPF rejects the orbital-rate dB/dt artifact; detumble unaffected.')
+        print('  Still required before lifting the bdot_gain freeze: a run against')
+        print('  the opensvf-kde OrbitalEnvironment model (not this dipole bench).')
+    else:
+        print('ISSUE #70 BENCH VALIDATION: FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sim/main.c
+++ b/sim/main.c
@@ -227,6 +227,7 @@ static obsw_s20_param_t s20_params[] = {
     {.param_id = SRDB_PARAM_WATCHDOG_KICK_COUNT,     .value = {.u32 = 0}},
     {.param_id = SRDB_PARAM_WATCHDOG_TICKS_REMAINING,.value = {.u32 = 30}},
     {.param_id = SRDB_PARAM_BDOT_GAIN,               .value = {.f32 = 1.0e4f}},
+    {.param_id = SRDB_PARAM_BDOT_HPF_TAU,            .value = {.f32 = 15.0f}},
     {.param_id = SRDB_PARAM_ADCS_KP,                 .value = {.f32 = 0.5f}},
     {.param_id = SRDB_PARAM_ADCS_KD,                 .value = {.f32 = 0.1f}},
     /* Orbit and dynamics configuration (#68) — readable via TC(20,3) */
@@ -458,7 +459,7 @@ int main(void)
     obsw_bdot_config_t bdot_cfg = {
         .gain       = 1.0e4f,
         .max_dipole = 10.0f,
-        .hpf_tau    = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU, 30.0f),
+        .hpf_tau    = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU, 15.0f),
     };
     obsw_bdot_init(&bdot_ctx, &bdot_cfg);
 
@@ -519,7 +520,7 @@ int main(void)
                 adcs_ctx.config.kd          = s20_get_f32(SRDB_PARAM_ADCS_KD,        0.1f);
                 bdot_ctx.config.gain        = s20_get_f32(SRDB_PARAM_BDOT_GAIN,      1.0e4f);
                 bdot_ctx.config.max_dipole  = s20_get_f32(SRDB_PARAM_MTQ_MAX_DIPOLE, 10.0f);
-                bdot_ctx.config.hpf_tau     = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU,   30.0f);
+                bdot_ctx.config.hpf_tau     = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU,   15.0f);
 
                 if (cur_mode == OBSW_FSM_NOMINAL && sensor.st_valid && sensor.gyro_valid) {
                     /* Update nadir target from orbital parameters (runtime-tunable via S20) */

--- a/sim/main.c
+++ b/sim/main.c
@@ -458,6 +458,7 @@ int main(void)
     obsw_bdot_config_t bdot_cfg = {
         .gain       = 1.0e4f,
         .max_dipole = 10.0f,
+        .hpf_tau    = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU, 30.0f),
     };
     obsw_bdot_init(&bdot_ctx, &bdot_cfg);
 
@@ -518,6 +519,7 @@ int main(void)
                 adcs_ctx.config.kd          = s20_get_f32(SRDB_PARAM_ADCS_KD,        0.1f);
                 bdot_ctx.config.gain        = s20_get_f32(SRDB_PARAM_BDOT_GAIN,      1.0e4f);
                 bdot_ctx.config.max_dipole  = s20_get_f32(SRDB_PARAM_MTQ_MAX_DIPOLE, 10.0f);
+                bdot_ctx.config.hpf_tau     = s20_get_f32(SRDB_PARAM_BDOT_HPF_TAU,   30.0f);
 
                 if (cur_mode == OBSW_FSM_NOMINAL && sensor.st_valid && sensor.gyro_valid) {
                     /* Update nadir target from orbital parameters (runtime-tunable via S20) */
@@ -569,8 +571,23 @@ int main(void)
                     act.mtq_dipole_z = bdot_out.m_cmd[2];
                     act.controller   = 0;
                     hk_aocs_ctrl     = 1U; /* B-dot */
+                    /* Issue #70: log raw and HPF-filtered dB/dt to quantify orbital aliasing */
+                    float dbdt_raw_mag = sqrtf(
+                        bdot_out.dbdt[0]*bdot_out.dbdt[0] +
+                        bdot_out.dbdt[1]*bdot_out.dbdt[1] +
+                        bdot_out.dbdt[2]*bdot_out.dbdt[2]);
+                    float dbdt_filt_mag = sqrtf(
+                        bdot_out.dbdt_filt[0]*bdot_out.dbdt_filt[0] +
+                        bdot_out.dbdt_filt[1]*bdot_out.dbdt_filt[1] +
+                        bdot_out.dbdt_filt[2]*bdot_out.dbdt_filt[2]);
                     fprintf(stderr,
-                        "[OBSW] bdot m=[%.3e,%.3e,%.3e] Am2\n",
+                        "[OBSW] bdot raw=[%.3e,%.3e,%.3e] T/s |raw|=%.3e"
+                        " filt=[%.3e,%.3e,%.3e] T/s |filt|=%.3e"
+                        " m=[%.3e,%.3e,%.3e] Am2\n",
+                        bdot_out.dbdt[0], bdot_out.dbdt[1], bdot_out.dbdt[2],
+                        dbdt_raw_mag,
+                        bdot_out.dbdt_filt[0], bdot_out.dbdt_filt[1], bdot_out.dbdt_filt[2],
+                        dbdt_filt_mag,
                         act.mtq_dipole_x, act.mtq_dipole_y, act.mtq_dipole_z);
                 } else {
                     hk_aocs_ctrl = 0U; /* STANDBY or sensors invalid */

--- a/src/aocs/bdot.c
+++ b/src/aocs/bdot.c
@@ -17,7 +17,9 @@ void obsw_bdot_init(obsw_bdot_ctx_t *ctx, const obsw_bdot_config_t *config)
         return;
     ctx->config      = *config;
     ctx->initialised = false;
-    memset(ctx->b_prev, 0, sizeof(ctx->b_prev));
+    memset(ctx->b_prev,         0, sizeof(ctx->b_prev));
+    memset(ctx->dbdt_raw_prev,  0, sizeof(ctx->dbdt_raw_prev));
+    memset(ctx->dbdt_filt,      0, sizeof(ctx->dbdt_filt));
 }
 
 void obsw_bdot_reset(obsw_bdot_ctx_t *ctx)
@@ -25,7 +27,9 @@ void obsw_bdot_reset(obsw_bdot_ctx_t *ctx)
     if (!ctx)
         return;
     ctx->initialised = false;
-    memset(ctx->b_prev, 0, sizeof(ctx->b_prev));
+    memset(ctx->b_prev,        0, sizeof(ctx->b_prev));
+    memset(ctx->dbdt_raw_prev, 0, sizeof(ctx->dbdt_raw_prev));
+    memset(ctx->dbdt_filt,     0, sizeof(ctx->dbdt_filt));
 }
 
 void obsw_bdot_step(obsw_bdot_ctx_t *ctx, const float b[3], float dt, obsw_bdot_output_t *out)
@@ -41,6 +45,7 @@ void obsw_bdot_step(obsw_bdot_ctx_t *ctx, const float b[3], float dt, obsw_bdot_
         ctx->initialised = true;
         out->m_cmd[0] = out->m_cmd[1] = out->m_cmd[2] = 0.0f;
         out->dbdt[0] = out->dbdt[1] = out->dbdt[2] = 0.0f;
+        out->dbdt_filt[0] = out->dbdt_filt[1] = out->dbdt_filt[2] = 0.0f;
         return;
     }
 
@@ -50,12 +55,30 @@ void obsw_bdot_step(obsw_bdot_ctx_t *ctx, const float b[3], float dt, obsw_bdot_
     dbdt[1] = (b[1] - ctx->b_prev[1]) / dt;
     dbdt[2] = (b[2] - ctx->b_prev[2]) / dt;
 
-    /* B-dot law: m_cmd = -k * dB/dt */
+    /* Optional first-order high-pass filter: y[k] = α(y[k-1] + x[k] - x[k-1])
+     * Rejects slow orbital-field variation while passing attitude-rate dB/dt.
+     * α = τ/(τ+dt); τ=0 disables the filter (dbdt_filt = dbdt). */
+    float dbdt_eff[3];
+    if (ctx->config.hpf_tau > 0.0f) {
+        float alpha = ctx->config.hpf_tau / (ctx->config.hpf_tau + dt);
+        for (int i = 0; i < 3; i++) {
+            ctx->dbdt_filt[i] = alpha * (ctx->dbdt_filt[i]
+                                          + dbdt[i] - ctx->dbdt_raw_prev[i]);
+            ctx->dbdt_raw_prev[i] = dbdt[i];
+            dbdt_eff[i] = ctx->dbdt_filt[i];
+        }
+    } else {
+        dbdt_eff[0] = dbdt[0];
+        dbdt_eff[1] = dbdt[1];
+        dbdt_eff[2] = dbdt[2];
+    }
+
+    /* B-dot law: m_cmd = -k * dB/dt_eff */
     float k = ctx->config.gain;
     float m[3];
-    m[0] = -k * dbdt[0];
-    m[1] = -k * dbdt[1];
-    m[2] = -k * dbdt[2];
+    m[0] = -k * dbdt_eff[0];
+    m[1] = -k * dbdt_eff[1];
+    m[2] = -k * dbdt_eff[2];
 
     /* Saturate dipole commands */
     float max = ctx->config.max_dipole;
@@ -66,12 +89,15 @@ void obsw_bdot_step(obsw_bdot_ctx_t *ctx, const float b[3], float dt, obsw_bdot_
             m[i] = -max;
     }
 
-    out->m_cmd[0] = m[0];
-    out->m_cmd[1] = m[1];
-    out->m_cmd[2] = m[2];
-    out->dbdt[0]  = dbdt[0];
-    out->dbdt[1]  = dbdt[1];
-    out->dbdt[2]  = dbdt[2];
+    out->m_cmd[0]     = m[0];
+    out->m_cmd[1]     = m[1];
+    out->m_cmd[2]     = m[2];
+    out->dbdt[0]      = dbdt[0];
+    out->dbdt[1]      = dbdt[1];
+    out->dbdt[2]      = dbdt[2];
+    out->dbdt_filt[0] = dbdt_eff[0];
+    out->dbdt_filt[1] = dbdt_eff[1];
+    out->dbdt_filt[2] = dbdt_eff[2];
 
     /* Update previous measurement */
     ctx->b_prev[0] = b[0];

--- a/src/task/aocs.c
+++ b/src/task/aocs.c
@@ -45,7 +45,7 @@ static void aocs_task(void *param)
 
         /* Sync S20-tunable gains — reads are atomic (32-bit, single-core ARM) */
         s_bdot.config.gain    = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_GAIN,    1.0e4f);
-        s_bdot.config.hpf_tau = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_HPF_TAU, 30.0f);
+        s_bdot.config.hpf_tau = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_HPF_TAU, 15.0f);
         s_adcs.config.kp      = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KP,      0.5f);
         s_adcs.config.kd      = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KD,      0.1f);
 
@@ -77,7 +77,7 @@ static void aocs_task(void *param)
 
 void obsw_aocs_task_init(void)
 {
-    obsw_bdot_config_t bdot_cfg = {.gain = 1.0e4f, .max_dipole = 10.0f, .hpf_tau = 30.0f};
+    obsw_bdot_config_t bdot_cfg = {.gain = 1.0e4f, .max_dipole = 10.0f, .hpf_tau = 15.0f};
     obsw_bdot_init(&s_bdot, &bdot_cfg);
 
     obsw_adcs_config_t adcs_cfg = {.kp = 0.5f, .kd = 0.1f, .max_torque = 0.01f};

--- a/src/task/aocs.c
+++ b/src/task/aocs.c
@@ -44,9 +44,10 @@ static void aocs_task(void *param)
             continue;
 
         /* Sync S20-tunable gains — reads are atomic (32-bit, single-core ARM) */
-        s_bdot.config.gain = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_GAIN, 1.0e4f);
-        s_adcs.config.kp   = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KP,   0.5f);
-        s_adcs.config.kd   = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KD,   0.1f);
+        s_bdot.config.gain    = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_GAIN,    1.0e4f);
+        s_bdot.config.hpf_tau = obsw_pus_s20_get_float(SRDB_PARAM_BDOT_HPF_TAU, 30.0f);
+        s_adcs.config.kp      = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KP,      0.5f);
+        s_adcs.config.kd      = obsw_pus_s20_get_float(SRDB_PARAM_ADCS_KD,      0.1f);
 
         /* ---- Sensor reads ---- */
         float b[3]             = {0.0f, 0.0f, 0.0f};
@@ -76,7 +77,7 @@ static void aocs_task(void *param)
 
 void obsw_aocs_task_init(void)
 {
-    obsw_bdot_config_t bdot_cfg = {.gain = 1.0e4f, .max_dipole = 10.0f};
+    obsw_bdot_config_t bdot_cfg = {.gain = 1.0e4f, .max_dipole = 10.0f, .hpf_tau = 30.0f};
     obsw_bdot_init(&s_bdot, &bdot_cfg);
 
     obsw_adcs_config_t adcs_cfg = {.kp = 0.5f, .kd = 0.1f, .max_torque = 0.01f};

--- a/src/task/pus.c
+++ b/src/task/pus.c
@@ -51,9 +51,10 @@ static obsw_s20_param_t s20_params[] = {
     {.param_id = SRDB_PARAM_SAFE_MODE_ENTRY_COUNT, .value = {.u32 = 0}},
     {.param_id = SRDB_PARAM_WATCHDOG_KICK_COUNT,   .value = {.u32 = 0}},
     /* AOCS control gains — tunable via TC(20,1), read by AOCS task each tick */
-    {.param_id = SRDB_PARAM_BDOT_GAIN, .value = {.f32 = 1.0e4f}},
-    {.param_id = SRDB_PARAM_ADCS_KP,   .value = {.f32 = 0.5f}},
-    {.param_id = SRDB_PARAM_ADCS_KD,   .value = {.f32 = 0.1f}},
+    {.param_id = SRDB_PARAM_BDOT_GAIN,    .value = {.f32 = 1.0e4f}},
+    {.param_id = SRDB_PARAM_BDOT_HPF_TAU, .value = {.f32 = 15.0f}},
+    {.param_id = SRDB_PARAM_ADCS_KP,      .value = {.f32 = 0.5f}},
+    {.param_id = SRDB_PARAM_ADCS_KD,      .value = {.f32 = 0.1f}},
 };
 
 /* S8 function table — mode transition requests via Mode Manager. */

--- a/srdb/data/parameters.yaml
+++ b/srdb/data/parameters.yaml
@@ -194,7 +194,7 @@ parameters:
 
   - id: 0x20A3
     name: bdot_hpf_tau
-    description: "B-dot HPF time constant τ [s] — first-order high-pass filter that rejects orbital-rate dB/dt while passing attitude-rate dB/dt. Set to 0 to disable. Typical: 30 s."
+    description: "B-dot HPF time constant τ [s] — first-order high-pass filter that rejects orbital-rate dB/dt while passing attitude-rate dB/dt. Set to 0 to disable. Typical: 15 s (bench-validated for 550 km SSO, issue #70)."
     type: float32
     ptc: 5
     pfc: 1

--- a/srdb/data/parameters.yaml
+++ b/srdb/data/parameters.yaml
@@ -192,6 +192,17 @@ parameters:
     subsystem: AOCS/Control
     unit: 'Am2.s/T'
 
+  - id: 0x20A3
+    name: bdot_hpf_tau
+    description: "B-dot HPF time constant τ [s] — first-order high-pass filter that rejects orbital-rate dB/dt while passing attitude-rate dB/dt. Set to 0 to disable. Typical: 30 s."
+    type: float32
+    ptc: 5
+    pfc: 1
+    subsystem: AOCS/Control
+    unit: s
+    limits:
+      soft_low: 0.0
+
   - id: 0x20A1
     name: adcs_kp
     description: "ADCS PD proportional gain Kp (τ = -Kp*q_err_vec - Kd*ω)"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,7 +74,7 @@ add_test(NAME s5_fdir COMMAND test_s5_fdir)
 # v0.5 — AOCS (including bdot)
 
 add_executable(test_bdot unit/test_bdot.c)
-target_link_libraries(test_bdot PRIVATE obsw unity)
+target_link_libraries(test_bdot PRIVATE obsw unity m)
 target_compile_options(test_bdot PRIVATE ${TEST_SUPPRESS})
 add_test(NAME bdot COMMAND test_bdot)
 

--- a/test/unit/test_bdot.c
+++ b/test/unit/test_bdot.c
@@ -143,6 +143,74 @@ void test_runtime_gain_update(void)
     TEST_ASSERT_FLOAT_WITHIN(1e-6f, 2.0f * m_gain1, m_gain2);
 }
 
+void test_hpf_disabled_matches_raw(void)
+{
+    /* hpf_tau = 0 → dbdt_filt must equal dbdt (no filtering) */
+    obsw_bdot_ctx_t ctx;
+    obsw_bdot_config_t cfg = {.gain = 1e4f, .max_dipole = 100.0f, .hpf_tau = 0.0f};
+    obsw_bdot_init(&ctx, &cfg);
+
+    float b0[3] = {0.0f, 0.0f, 0.0f};
+    float b1[3] = {1e-4f, 2e-4f, -1e-4f};
+    obsw_bdot_output_t out;
+
+    obsw_bdot_step(&ctx, b0, 0.1f, &out);
+    obsw_bdot_step(&ctx, b1, 0.1f, &out);
+
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, out.dbdt[0], out.dbdt_filt[0]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, out.dbdt[1], out.dbdt_filt[1]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-9f, out.dbdt[2], out.dbdt_filt[2]);
+}
+
+void test_hpf_attenuates_dc_drift(void)
+{
+    /* A slowly-rising field (orbital drift) must be attenuated by the HPF.
+     * After many steps the filtered dB/dt should be much smaller than the
+     * raw dB/dt for a constant-rate input (DC → 0 in steady state). */
+    obsw_bdot_ctx_t ctx;
+    obsw_bdot_config_t cfg = {.gain = 1.0f, .max_dipole = 1000.0f, .hpf_tau = 10.0f};
+    obsw_bdot_init(&ctx, &cfg);
+
+    float dt = 0.1f;
+    float step = 1e-7f;  /* tiny constant dB/dt — simulates orbital drift */
+    float b[3] = {0.0f, 0.0f, 0.0f};
+    obsw_bdot_output_t out;
+
+    /* Drive 500 steps (~50 s >> tau=10 s) with constant dB/dt */
+    for (int i = 0; i < 500; i++) {
+        b[0] += step * dt;
+        obsw_bdot_step(&ctx, b, dt, &out);
+    }
+
+    /* HPF in steady state with constant input → output → 0 */
+    TEST_ASSERT_TRUE(fabsf(out.dbdt_filt[0]) < fabsf(out.dbdt[0]) * 0.01f);
+}
+
+void test_hpf_passes_attitude_rate(void)
+{
+    /* A higher-frequency oscillation (attitude tumble rate) must pass through.
+     * After HPF settles, the filtered amplitude should be close to the raw
+     * amplitude for a sinusoidal input well above the corner frequency. */
+    obsw_bdot_ctx_t ctx;
+    obsw_bdot_config_t cfg = {.gain = 1.0f, .max_dipole = 1000.0f, .hpf_tau = 10.0f};
+    obsw_bdot_init(&ctx, &cfg);
+
+    float dt = 0.1f;
+    float freq = 0.5f;     /* 0.5 Hz — well above f_c = 1/(2π*10) ≈ 0.016 Hz */
+    float amp  = 1e-5f;    /* field amplitude */
+    obsw_bdot_output_t out;
+
+    /* Run enough cycles for HPF to settle */
+    for (int i = 0; i < 200; i++) {
+        float t  = i * dt;
+        float b[3] = {amp * sinf(2.0f * 3.14159265f * freq * t), 0.0f, 0.0f};
+        obsw_bdot_step(&ctx, b, dt, &out);
+    }
+
+    /* At 0.5 Hz with tau=10s: |H(jω)| = ωτ/√(1+(ωτ)²) ≈ 0.9995 — nearly flat pass */
+    TEST_ASSERT_TRUE(fabsf(out.dbdt_filt[0]) > fabsf(out.dbdt[0]) * 0.90f);
+}
+
 int main(void)
 {
     UNITY_BEGIN();
@@ -153,5 +221,8 @@ int main(void)
     RUN_TEST(test_reset_clears_state);
     RUN_TEST(test_opposing_field_reversal);
     RUN_TEST(test_runtime_gain_update);
+    RUN_TEST(test_hpf_disabled_matches_raw);
+    RUN_TEST(test_hpf_attenuates_dc_drift);
+    RUN_TEST(test_hpf_passes_attitude_rate);
     return UNITY_END();
 }


### PR DESCRIPTION
(Recreates #77, which GitHub auto-closed when its base branch
`sync/main-v0.15-hil-zynqmp` was deleted after #76 merged, instead of
retargeting it.)

## Summary
First-order washout (high-pass) filter on the B-dot `dB/dt` estimate to reject the orbit-induced magnetic-field gradient that otherwise aliases into a spurious dipole command at zero attitude rate.

- `y[k] = alpha*(y[k-1] + x[k] - x[k-1])`, `alpha = tau/(tau+dt)`; `tau = 0` disables (passthrough)
- Time constant is SRDB param `bdot_hpf_tau` (**0x20A3**, float32 s, default **15 s**), re-synced from the S20 store every control tick in `sim/main.c` and `src/task/aocs.c`
- Registered in the S20 tables of `sim/main.c` and `src/task/pus.c` - live retune via `TC(20,1)` / read via `TC(20,3)`
- `obsw_bdot_output_t` now carries both `dbdt[3]` (raw) and `dbdt_filt[3]` (filtered) for telemetry
- `sim/bdot_hpf_validation.py` bench harness; `docs/issue-70-opensvf-kde-handoff.md` documents the remaining cross-repo validation

## Testing
- New unit tests: `test_hpf_disabled_matches_raw`, `test_hpf_attenuates_dc_drift`, `test_hpf_passes_attitude_rate` (`ctest -R bdot`)
- Bench (550 km SSO, geocentric-dipole field): steady-state spurious `|m_cmd|` rejection 8.9x at tau=15 s; detumble (omega0=0.3 rad/s) still converges in 0.35 orbits

## Scope - does NOT close #70
Bench validation uses a simplified geocentric-dipole field. Issue #70 stays open until a null-attitude + tumbling pass on the opensvf-kde `OrbitalEnvironment` model confirms rejection; only then lift the `bdot_gain` (0x20A0) retune freeze. Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
